### PR TITLE
Fix DurableAgent JSON serialization for SQLiteStore

### DIFF
--- a/src/durable/pydantic_ai.py
+++ b/src/durable/pydantic_ai.py
@@ -69,6 +69,20 @@ def _deserialize_messages(data: list[dict]) -> list[Any]:
     return result
 
 
+def _serialize_run_result(result: Any) -> dict:
+    """Convert an agent RunResult to a JSON-serializable dict."""
+    output = result.output
+    # If output is a pydantic model, convert to dict
+    if hasattr(output, "model_dump"):
+        output = output.model_dump(mode="json")
+    data: dict[str, Any] = {"output": output}
+    try:
+        data["all_messages"] = _serialize_messages(result.all_messages())
+    except Exception:
+        data["all_messages"] = []
+    return data
+
+
 def _run_id_for_agent(agent_name: str, prompt: str, run_id: str | None) -> str:
     """Generate a deterministic run ID from the agent name and prompt."""
     if run_id:
@@ -207,7 +221,7 @@ class DurableAgent(Generic[AgentDepsT, OutputT]):
             step_id="agent-run",
             **kwargs,
         )
-        return result
+        return _AgentRunResult(result)
 
     async def _do_model_request(
         self,
@@ -225,7 +239,7 @@ class DurableAgent(Generic[AgentDepsT, OutputT]):
         run_kwargs.update(kwargs)
 
         result = await self.agent.run(prompt, **run_kwargs)
-        return _AgentRunResult(result)
+        return _serialize_run_result(result)
 
     async def _do_tool_call(
         self,

--- a/tests/test_pydantic_ai.py
+++ b/tests/test_pydantic_ai.py
@@ -326,3 +326,19 @@ class TestIntegration:
         r2 = await durable.run("What is 6*7?", run_id="calc-1")
         assert r2.output == "42"
         assert agent.run.call_count == 1
+
+    async def test_durable_agent_with_sqlite_store(self, tmp_path):
+        """Ensure agent results are JSON-serializable for SQLiteStore."""
+        db_path = str(tmp_path / "test.db")
+        wf = Workflow("test-sqlite", db=db_path)
+
+        agent, _ = _mock_agent(output="serialized ok")
+        durable = DurableAgent(agent, wf, name="sqlite-agent")
+
+        r1 = await durable.run("Test prompt", run_id="sqlite-1")
+        assert r1.output == "serialized ok"
+        assert agent.run.call_count == 1
+
+        r2 = await durable.run("Test prompt", run_id="sqlite-1")
+        assert r2.output == "serialized ok"
+        assert agent.run.call_count == 1


### PR DESCRIPTION
## Summary
- `_do_model_request` returned an `_AgentRunResult` object that `SQLiteStore` could not `json.dumps()`, causing a `TypeError` at runtime
- Serialize the agent result to a dict before storing, and wrap it back into `_AgentRunResult` on retrieval
- Added a SQLiteStore-backed test to prevent regression — existing tests only used `InMemoryStore` which skips JSON serialization

## Test plan
- [x] All 29 existing tests pass
- [x] New `test_durable_agent_with_sqlite_store` test exercises the full serialize/deserialize path
- [x] ruff and ty pass clean
