### PR TITLE
Fix DurableAgent returning dict instead of Pydantic model on replay

### DIFF
--- a/src/durable/pydantic_ai.py
+++ b/src/durable/pydantic_ai.py
@@ -221,7 +221,8 @@ class DurableAgent(Generic[AgentDepsT, OutputT]):
             step_id="agent-run",
             **kwargs,
         )
-        return _AgentRunResult(result)
+        output_type = getattr(self.agent, "_output_type", None)
+        return _AgentRunResult(result, output_type=output_type)
 
     async def _do_model_request(
         self,
@@ -282,15 +283,19 @@ class _AgentRunResult:
     """Wrapper that holds an agent RunResult and handles both live and
     deserialized (dict) results transparently."""
 
-    def __init__(self, result: Any) -> None:
+    def __init__(self, result: Any, output_type: type | None = None) -> None:
         self._result = result
+        self._output_type = output_type
 
     @property
     def output(self) -> Any:
         if hasattr(self._result, "output"):
             return self._result.output
         if isinstance(self._result, dict):
-            return self._result.get("output")
+            raw = self._result.get("output")
+            if isinstance(raw, dict) and self._output_type and hasattr(self._output_type, "model_validate"):
+                return self._output_type.model_validate(raw)
+            return raw
         return self._result
 
     @property

--- a/tests/test_pydantic_ai.py
+++ b/tests/test_pydantic_ai.py
@@ -342,3 +342,73 @@ class TestIntegration:
         r2 = await durable.run("Test prompt", run_id="sqlite-1")
         assert r2.output == "serialized ok"
         assert agent.run.call_count == 1
+
+    async def test_pydantic_model_output_preserved_on_replay(self, wf):
+        """Pydantic model output should be re-hydrated on replay, not returned as dict."""
+        from pydantic import BaseModel
+
+        class CityInfo(BaseModel):
+            name: str
+            population: int
+
+        city = CityInfo(name="Paris", population=2_161_000)
+
+        agent, run_result = _mock_agent()
+        run_result.output = city
+        agent._output_type = CityInfo
+
+        durable = DurableAgent(agent, wf, name="city-agent")
+
+        r1 = await durable.run("Tell me about Paris", run_id="pydantic-1")
+        assert isinstance(r1.output, CityInfo)
+        assert r1.output.name == "Paris"
+        assert agent.run.call_count == 1
+
+        # Replay — should still return a CityInfo, not a dict
+        r2 = await durable.run("Tell me about Paris", run_id="pydantic-1")
+        assert isinstance(r2.output, CityInfo)
+        assert r2.output.name == "Paris"
+        assert r2.output.population == 2_161_000
+        assert agent.run.call_count == 1
+
+    async def test_plain_string_output_no_regression(self, wf):
+        """Plain string outputs should still work after the output_type change."""
+        agent, _ = _mock_agent(output="just a string")
+        agent._output_type = None
+
+        durable = DurableAgent(agent, wf, name="string-agent")
+
+        r1 = await durable.run("Say hello", run_id="string-1")
+        assert r1.output == "just a string"
+
+        r2 = await durable.run("Say hello", run_id="string-1")
+        assert r2.output == "just a string"
+
+
+class TestAgentRunResultRehydration:
+    def test_rehydrate_dict_with_output_type(self):
+        from pydantic import BaseModel
+
+        class Item(BaseModel):
+            id: int
+            label: str
+
+        wrapper = _AgentRunResult({"output": {"id": 1, "label": "test"}}, output_type=Item)
+        result = wrapper.output
+        assert isinstance(result, Item)
+        assert result.id == 1
+        assert result.label == "test"
+
+    def test_no_rehydrate_without_output_type(self):
+        wrapper = _AgentRunResult({"output": {"id": 1, "label": "test"}})
+        result = wrapper.output
+        assert isinstance(result, dict)
+
+    def test_no_rehydrate_non_dict_output(self):
+        from pydantic import BaseModel
+
+        class Item(BaseModel):
+            id: int
+
+        wrapper = _AgentRunResult({"output": "plain string"}, output_type=Item)
+        assert wrapper.output == "plain string"


### PR DESCRIPTION
## Summary
- When `DurableAgent` wraps an agent with a Pydantic `output_type`, replay (cache hit) returned a plain `dict` instead of the expected Pydantic model because `_serialize_run_result()` calls `model_dump()` but nothing re-hydrated the output on deserialization.
- `_AgentRunResult` now accepts an `output_type` and uses `model_validate()` to reconstruct the Pydantic model when the raw output is a dict.
- `_execute_agent_loop` extracts `_output_type` from the wrapped agent and passes it through.

Fixes #3

## Test plan
- [x] New test: Pydantic model output preserved on replay (`test_pydantic_model_output_preserved_on_replay`)
- [x] New test: dict→model rehydration in `_AgentRunResult` (`test_rehydrate_dict_with_output_type`)
- [x] New test: no rehydration without output_type (`test_no_rehydrate_without_output_type`)
- [x] New test: non-dict output passed through unchanged (`test_no_rehydrate_non_dict_output`)
- [x] New test: plain string outputs still work (`test_plain_string_output_no_regression`)
- [x] All 34 tests pass
