### PR TITLE
Fix @wf.task Pydantic model serialization/deserialization

### DIFF
--- a/src/durable/redis_store.py
+++ b/src/durable/redis_store.py
@@ -18,6 +18,8 @@ _WRAP_KEY = "v"
 
 
 def _wrap(value: Any) -> str:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
     return json.dumps({_WRAP_KEY: value})
 
 
@@ -71,6 +73,8 @@ class RedisStore(Store):
     async def set_step(
         self, run_id: str, step_id: str, result: Any, attempt: int = 1
     ) -> None:
+        if hasattr(result, "model_dump"):
+            result = result.model_dump(mode="json")
         payload = json.dumps({"v": result, "attempt": attempt})
         key = _step_key(self._prefix, run_id, step_id)
         client = self._client()

--- a/src/durable/store.py
+++ b/src/durable/store.py
@@ -23,6 +23,8 @@ _WRAP_KEY = "v"
 
 
 def _wrap(value: Any) -> str:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump(mode="json")
     return json.dumps({_WRAP_KEY: value})
 
 

--- a/src/durable/workflow.py
+++ b/src/durable/workflow.py
@@ -26,7 +26,7 @@ import functools
 import inspect
 import logging
 import re
-from typing import Any, Callable, ParamSpec, TypeVar, overload
+from typing import Any, Callable, ParamSpec, TypeVar, get_type_hints, overload
 
 from .backoff import BackoffStrategy, exponential
 from .context import RunContext, _active_run
@@ -74,6 +74,12 @@ class _TaskWrapper:
         self._step_name = step_name
         self._retries = retries
         self._backoff = backoff
+        # Extract return type hint for Pydantic model rehydration on replay
+        try:
+            hints = get_type_hints(fn)
+        except Exception:
+            hints = {}
+        self._return_type = hints.get("return")
         # Preserve the original function's metadata for IDE / tooling support
         functools.update_wrapper(self, fn)
 
@@ -97,7 +103,7 @@ class _TaskWrapper:
             log.debug(
                 "[durable] ↩  %s (step=%s) — replayed from store", self._step_name, sid
             )
-            return cached
+            return self._rehydrate(cached)
 
         return await self._execute_with_retry(ctx, sid, args, kwargs)
 
@@ -136,6 +142,17 @@ class _TaskWrapper:
                 )
 
         raise last_exc  # type: ignore[misc]
+
+    def _rehydrate(self, value: Any) -> Any:
+        """Re-inflate a cached dict into a Pydantic model if the return type hint says so."""
+        if (
+            isinstance(value, dict)
+            and self._return_type is not None
+            and isinstance(self._return_type, type)
+            and hasattr(self._return_type, "model_validate")
+        ):
+            return self._return_type.model_validate(value)
+        return value
 
     def __repr__(self) -> str:
         return f"<DurableTask '{self._step_name}' retries={self._retries}>"

--- a/tests/test_durable.py
+++ b/tests/test_durable.py
@@ -240,3 +240,128 @@ async def test_task_reuse_across_workflows():
         assert call_log == []
 
     print("  ✓ Shared tasks are isolated per workflow run")
+
+
+# ---------------------------------------------------------------------------
+# 7. Pydantic model serialization/deserialization in @wf.task
+# ---------------------------------------------------------------------------
+
+from pydantic import BaseModel
+
+
+class UserModel(BaseModel):
+    id: int
+    name: str
+    email: str
+
+
+async def test_pydantic_model_serializes_from_task():
+    """Pydantic model returned from @wf.task serializes without error on first run."""
+    with tempfile.TemporaryDirectory() as tmp:
+        wf = make_wf(tmp)
+
+        @wf.task
+        async def fetch_user() -> UserModel:
+            return UserModel(id=1, name="Alice", email="alice@example.com")
+
+        @wf.workflow(id="test-pydantic-serialize")
+        async def my_workflow() -> UserModel:
+            return await fetch_user()
+
+        result = await my_workflow()
+        assert isinstance(result, UserModel)
+        assert result.id == 1
+        assert result.name == "Alice"
+
+
+async def test_pydantic_model_rehydrated_on_replay():
+    """Pydantic model is correctly rehydrated on replay (not returned as dict)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        wf = make_wf(tmp)
+        call_log = []
+
+        @wf.task
+        async def fetch_user() -> UserModel:
+            call_log.append("fetch")
+            return UserModel(id=2, name="Bob", email="bob@example.com")
+
+        @wf.workflow(id="test-pydantic-replay")
+        async def my_workflow() -> UserModel:
+            return await fetch_user()
+
+        # First run
+        result = await my_workflow()
+        assert isinstance(result, UserModel)
+        assert call_log == ["fetch"]
+
+        # Second run — replayed from store
+        call_log.clear()
+        result = await my_workflow()
+        assert call_log == [], "Task was re-executed but should have been replayed!"
+        assert isinstance(result, UserModel), f"Expected UserModel, got {type(result)}"
+        assert result.id == 2
+        assert result.name == "Bob"
+
+
+async def test_plain_types_still_work():
+    """Plain dict/string/int returns still work (no regression)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        wf = make_wf(tmp)
+
+        @wf.task
+        async def return_dict() -> dict:
+            return {"key": "value"}
+
+        @wf.task
+        async def return_str() -> str:
+            return "hello"
+
+        @wf.task
+        async def return_int() -> int:
+            return 42
+
+        @wf.workflow(id="test-plain-types")
+        async def my_workflow():
+            d = await return_dict()
+            s = await return_str()
+            i = await return_int()
+            return d, s, i
+
+        d, s, i = await my_workflow()
+        assert d == {"key": "value"}
+        assert s == "hello"
+        assert i == 42
+
+        # Replay
+        d, s, i = await my_workflow()
+        assert d == {"key": "value"}
+        assert s == "hello"
+        assert i == 42
+
+
+async def test_pydantic_without_return_type_hint():
+    """Task without return type hint still serializes Pydantic models (but no rehydration)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        wf = make_wf(tmp)
+        call_log = []
+
+        @wf.task
+        async def fetch_user():
+            call_log.append("fetch")
+            return UserModel(id=3, name="Charlie", email="charlie@example.com")
+
+        @wf.workflow(id="test-pydantic-no-hint")
+        async def my_workflow():
+            return await fetch_user()
+
+        # First run — should serialize without error
+        result = await my_workflow()
+        assert result.id == 3
+        assert call_log == ["fetch"]
+
+        # Replay — no type hint, so it comes back as dict (no rehydration)
+        call_log.clear()
+        result = await my_workflow()
+        assert call_log == []
+        assert isinstance(result, dict), f"Expected dict without type hint, got {type(result)}"
+        assert result["id"] == 3


### PR DESCRIPTION
## Summary
- **Serialization**: `_wrap()` in `store.py` and `redis_store.py` now calls `model_dump(mode="json")` on Pydantic models before `json.dumps()`, fixing `TypeError: Object of type MyModel is not JSON serializable`
- **Deserialization**: `_TaskWrapper` extracts the return type hint at init time and rehydrates cached dicts back into Pydantic models on replay via `model_validate()`
- Mirrors the existing fix in `DurableAgent` for agent outputs (PR #4)

Closes #6

## Test plan
- [x] Existing 6 tests pass (no regression)
- [x] New test: Pydantic model serializes from `@wf.task` without error
- [x] New test: Pydantic model rehydrated on replay (returns BaseModel, not dict)
- [x] New test: Plain dict/string/int returns still work
- [x] New test: Task without return type hint serializes but returns dict on replay
